### PR TITLE
Add resource_id to get_metric validation schema

### DIFF
--- a/flexer/tests/module_with_metrics.py
+++ b/flexer/tests/module_with_metrics.py
@@ -4,7 +4,8 @@ def test_ok(event, context):
         'metric': 'cpu-usage',
         'value': 99,
         'unit': 'percent',
-        'time': '2017-01-12T18:30:42.034751Z'}
+        'time': '2017-01-12T18:30:42.034751Z',
+        'resource_id': '1237ab91-08eb-4164-8e68-67699c29cd4c'}
         ]}
 
 

--- a/flexer/tests/test_runner.py
+++ b/flexer/tests/test_runner.py
@@ -295,7 +295,8 @@ class TestFlexer(unittest.TestCase):
                 u'metric': u'cpu-usage',
                 u'value': 99,
                 u'unit': u'percent',
-                u'time': u'2017-01-12T18:30:42.034751Z'}
+                u'time': u'2017-01-12T18:30:42.034751Z',
+                u'resource_id': u'1237ab91-08eb-4164-8e68-67699c29cd4c'}
                 ]},
             u'error': None,
             u'logs': u'Running test script\n',

--- a/flexer/validation/get_metrics.json
+++ b/flexer/validation/get_metrics.json
@@ -19,6 +19,11 @@
                         "type": "string",
                         "format": "datetime",
                         "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{6})?Z?$"
+                    },
+                    "resource_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "pattern": "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"
                     }
                 },
                 "required":[


### PR DESCRIPTION
As nflex connector support to get metrics for multiple resource at once,
we added resource_id field to the result data of get_metrics handler so
we can identify which metric belong to which resource.

This filed can be omitted, in this case that metrics will be associated
with resource which is passed to this handler. this is the same
bahaviour as before.