### PR TITLE
Moved module lib path before system lib when running the flexer cli ...

### DIFF
--- a/flexer/__init__.py
+++ b/flexer/__init__.py
@@ -1,4 +1,4 @@
 from flexer.clients.cmp import CmpClient
 from flexer.clients.nflex import NflexClient
 
-__version__ = '1.2.4'
+__version__ = '1.2.5'

--- a/flexer/cli.py
+++ b/flexer/cli.py
@@ -16,7 +16,7 @@ from flexer.utils import (
 import flexer.commands
 
 sys.path.append(os.getcwd())
-sys.path.append(os.path.join(os.getcwd(), "lib"))
+sys.path = [os.path.join(os.getcwd(), "lib")] + sys.path
 
 flexer.commands.assert_config_exists()
 

--- a/flexer/cli.py
+++ b/flexer/cli.py
@@ -15,8 +15,7 @@ from flexer.utils import (
 )
 import flexer.commands
 
-sys.path.append(os.getcwd())
-sys.path = [os.path.join(os.getcwd(), "lib")] + sys.path
+sys.path = [os.getcwd(), os.path.join(os.getcwd(), "lib")] + sys.path
 
 flexer.commands.assert_config_exists()
 


### PR DESCRIPTION
This solves an issue where older versions of packagesd installed on a
developer's machine get loaded instead of the ones installed in lib.