### PR TITLE
Add optional attributes to metrics return value

### DIFF
--- a/flexer/validation/get_metrics.json
+++ b/flexer/validation/get_metrics.json
@@ -9,11 +9,17 @@
                     "metric": {
                         "type": "string"
                     },
+                    "specialisation": {
+                        "type": "string"
+                    },
                     "value": {
                         "type": "number"
                     },
                     "unit": {
                         "type": "string"
+                    },
+                    "counter": {
+                        "type": "boolean"
                     },
                     "time":{
                         "type": "string",
@@ -24,6 +30,9 @@
                         "type": "string",
                         "format": "uuid",
                         "pattern": "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"
+                    },
+                    "provider_id": {
+                        "type": "string"
                     }
                 },
                 "required":[


### PR DESCRIPTION
- specialisation
- counter
- provider_id

Specialisation and counter are going to be explicit instead of encoded in the metric name.

