### PR TITLE
Add testing of get_logs method and set resource-id and account_id to root level of event

### DIFF
--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -158,3 +158,21 @@ class BaseConnectorTest(unittest.TestCase):
                 count = len(filter(lambda r: r["metric"] == name, metrics))
                 self.assertGreater(count, 0,
                                    'No metric points for "%s" found' % name)
+
+    @unittest.skipIf(not hasattr(main, "get_logs"),
+                     "get_logs not defined")
+    @unittest.skipIf(not hasattr(logs, "get"),
+                     "get not defined in logs")
+    def test_get_logs(self):
+        self.event['resource'] = self.account_resource
+        result = self.runner.run(handler="main.get_logs",
+                                 event=self.event,
+                                 context=self.context,
+                                 debug=self.logging)
+        result = json.loads(result)
+
+        self.assertIsNone(result["error"])
+        value = result["value"]
+        logs = value["logs"]
+        self.assertIsNotNone(logs)
+        self.assertGreater(len(logs), 0, 'No logs found')

--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -139,6 +139,8 @@ class BaseConnectorTest(unittest.TestCase):
     def test_get_metrics(self):
         for res in self.resource_data:
             self.event['resource'] = res['resource']
+            self.event['resource_id'] = res['resource']['id']
+            self.event['account_id'] = res['resource']['account_id']
             result = self.runner.run(handler="main.get_metrics",
                                      event=self.event,
                                      context=self.context,
@@ -163,6 +165,8 @@ class BaseConnectorTest(unittest.TestCase):
                      "get not defined in logs")
     def test_get_logs(self):
         self.event['resource'] = self.account_resource
+        self.event['resource_id'] = self.account_resource['id']
+        self.event['account_id'] = self.account_resource['account_id']
         result = self.runner.run(handler="main.get_logs",
                                  event=self.event,
                                  context=self.context,

--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -39,6 +39,9 @@ class BaseConnectorTest(unittest.TestCase):
                 }
             ]
 
+        if "account_resource" in cls.account:
+            cls.account_resource = cls.account.get("account_resource")
+
         cls.runner = Flexer()
         cfg = load_config(cfg_file=CONFIG_FILE)["regions"]["default"]
         client = CmpClient(url=cfg["cmp_url"],

--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -38,7 +38,7 @@ class BaseConnectorTest(unittest.TestCase):
                     "expected_metrics": cls.account.get("expected_metrics")
                 }
             ]
-        cls.account_resource = cls.account.get("account_resource")
+        cls.logs_resource = cls.account.get("logs_resource")
 
         cls.runner = Flexer()
         cfg = load_config(cfg_file=CONFIG_FILE)["regions"]["default"]
@@ -162,9 +162,9 @@ class BaseConnectorTest(unittest.TestCase):
     @unittest.skipIf(not hasattr(main, "get_logs"),
                      "get_logs not defined")
     def test_get_logs(self):
-        self.event['resource'] = self.account_resource
-        self.event['resource_id'] = self.account_resource['id']
-        self.event['account_id'] = self.account_resource['account_id']
+        self.event['resource'] = self.logs_resource
+        self.event['resource_id'] = self.logs_resource['id']
+        self.event['account_id'] = self.logs_resource['account_id']
         result = self.runner.run(handler="main.get_logs",
                                  event=self.event,
                                  context=self.context,

--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -38,9 +38,7 @@ class BaseConnectorTest(unittest.TestCase):
                     "expected_metrics": cls.account.get("expected_metrics")
                 }
             ]
-
-        if "account_resource" in cls.account:
-            cls.account_resource = cls.account.get("account_resource")
+        cls.account_resource = cls.account.get("account_resource")
 
         cls.runner = Flexer()
         cfg = load_config(cfg_file=CONFIG_FILE)["regions"]["default"]

--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -161,8 +161,6 @@ class BaseConnectorTest(unittest.TestCase):
 
     @unittest.skipIf(not hasattr(main, "get_logs"),
                      "get_logs not defined")
-    @unittest.skipIf(not hasattr(logs, "get"),
-                     "get not defined in logs")
     def test_get_logs(self):
         self.event['resource'] = self.account_resource
         self.event['resource_id'] = self.account_resource['id']


### PR DESCRIPTION
I added some testing code of getting logs.
Also I added new field "account_resource" to config.yaml because resource field in event is slightly different between server and account.