### PR TITLE
Remove validation of resource_id and provider_id fields

### DIFF
--- a/flexer/tests/module_with_metrics.py
+++ b/flexer/tests/module_with_metrics.py
@@ -4,8 +4,7 @@ def test_ok(event, context):
         'metric': 'cpu-usage',
         'value': 99,
         'unit': 'percent',
-        'time': '2017-01-12T18:30:42.034751Z',
-        'resource_id': '1237ab91-08eb-4164-8e68-67699c29cd4c'}
+        'time': '2017-01-12T18:30:42.034751Z'}
         ]}
 
 

--- a/flexer/tests/test_runner.py
+++ b/flexer/tests/test_runner.py
@@ -349,8 +349,7 @@ class TestFlexer(unittest.TestCase):
                 u'metric': u'cpu-usage',
                 u'value': 99,
                 u'unit': u'percent',
-                u'time': u'2017-01-12T18:30:42.034751Z',
-                u'resource_id': u'1237ab91-08eb-4164-8e68-67699c29cd4c'}
+                u'time': u'2017-01-12T18:30:42.034751Z'}
                 ]},
             u'error': None,
             u'logs': u'Running test script\n',

--- a/flexer/validation/get_metrics.json
+++ b/flexer/validation/get_metrics.json
@@ -28,14 +28,6 @@
                         "type": "string",
                         "format": "datetime",
                         "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,6})?Z?$"
-                    },
-                    "resource_id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "pattern": "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"
-                    },
-                    "provider_id": {
-                        "type": "string"
                     }
                 },
                 "required":[


### PR DESCRIPTION
We do not need these fields because they are automatically added by Lorentz.