### PR TITLE
Add --client-from-env option to flexer test

### DIFF
--- a/flexer/cli.py
+++ b/flexer/cli.py
@@ -458,8 +458,14 @@ def build(ctx, directory, zip, exclude):
               default=False,
               is_flag=True,
               help='Display verbose output from the test execution')
+@click.option('-e', '--client-from-env',
+              default=False,
+              is_flag=True,
+              help='Use CMP_URL, CMP_USERNAME, CMP_PASSWORD environment'
+              ' vars to create cmp api client to be passed to each test'
+              ' instead of ~/.flexer.yaml')
 @pass_context
-def test(ctx, verbose, keywords):
+def test(ctx, client_from_env, verbose, keywords):
     """Run the flexer base tests against a module.
 
     Run a very basic set of tests for a CMP connector. The tests are available
@@ -501,6 +507,7 @@ def test(ctx, verbose, keywords):
         is in the return value of the get_resources handler
     """
 
-    result = flexer.commands.test(verbose=verbose, keywords=keywords)
+    result = flexer.commands.test(verbose=verbose, keywords=keywords,
+                                  client_from_env=client_from_env)
     if len(result.failures) + len(result.errors) > 0:
         exit(1)

--- a/flexer/commands.py
+++ b/flexer/commands.py
@@ -148,10 +148,11 @@ def strip_dir_path(source, dirname):
     return prefix
 
 
-def test(verbose=False, keywords=None):
+def test(verbose=False, keywords=None, client_from_env=False):
     import unittest
     from flexer.connector_tests.test_base import BaseConnectorTest
 
+    BaseConnectorTest.use_configfile = not client_from_env
     if keywords:
         suite = unittest.TestLoader().loadTestsFromName('flexer.connector_tests.test_base.BaseConnectorTest.'+keywords)
     else:

--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -17,6 +17,8 @@ import re
 
 
 class BaseConnectorTest(unittest.TestCase):
+    # Use .flexer.yaml to create cmp client
+    use_configfile = True
 
     @classmethod
     def setUpClass(cls):
@@ -42,9 +44,11 @@ class BaseConnectorTest(unittest.TestCase):
             ]
 
         cls.runner = Flexer()
-        cfg = load_config(cfg_file=CONFIG_FILE)["regions"]["default"]
-        client = CmpClient(url=cfg["cmp_url"],
-                           auth=(cfg['cmp_api_key'], cfg['cmp_api_secret']))
+        client=None
+        if cls.use_configfile:
+            cfg = load_config(cfg_file=CONFIG_FILE)["regions"]["default"]
+            client = CmpClient(url=cfg["cmp_url"],
+                               auth=(cfg['cmp_api_key'], cfg['cmp_api_secret']))
         cls.context = FlexerContext(cmp_client=client)
         secrets = (lookup_values(cls.account.get("secrets_keys")))
         cls.context.secrets = secrets


### PR DESCRIPTION
This option allow us to specify cmp api credential via environment
variables. until we introduced this option, we needed to change
.flexer.yaml file everytime we change the connector we are working on.

This option will be used like bellow

$ PROVIDER_USER=test PROVIDER_PASS=test
CMP_URI=https://sandbox-cmp.nflex.io/cmp/basic/api CMP_USERNAME=cmpuser
CMP_PASSWORD=cmppass flexer test -e

by executing as above all tests will have the cmp api client with above
information uri to be https://sandbox-cmp.nflex.io/cmp/basic/api,
username to be cmpuser...