### PR TITLE
changed a return of context.database method

### DIFF
--- a/flexer/context.py
+++ b/flexer/context.py
@@ -45,7 +45,7 @@ class FlexerContext(object):
             ssl_ca_certs='/nflex-root.pem',
             connectTimeoutMS=3000)
 
-        return client.get_database()
+        return client
 
     def log(self, message, severity="info"):
         """Log a message to CMP."""


### PR DESCRIPTION
### When I tried to use "context.database", I encountered such an error.
```
=============================================================
  File "/libs/dist-packages/flexer/context.py", line 48, in database
    return client.get_database()
  File "/libs/dist-packages/pymongo/mongo_client.py", line 1325, in get_database
    raise ConfigurationError('No default database defined')
ConfigurationError: No default database defined
=============================================================
```
I feel that mongo_client.get_database() method need a database name, but  could not currently pass any arguments.
I think that there is no problem even if return "client".