### PR TITLE
Add the ability to explicitly skip logs testing on config.yaml

### DIFF
--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -31,6 +31,7 @@ class BaseConnectorTest(unittest.TestCase):
         cls.account["credentials"] = (
             lookup_values(cls.account.get("credentials_keys"))
         )
+        cls.skip_logs = cls.account.get('skip_logs', False)
         if "resources" in cls.account:
             cls.resource_data = cls.account.get("resources")
         else:
@@ -182,6 +183,8 @@ class BaseConnectorTest(unittest.TestCase):
     @unittest.skipIf(not hasattr(main, "get_logs"),
                      "get_logs not defined")
     def test_get_logs(self):
+        if self.skip_logs:
+            return
         counter = 0
         for res in self.resource_data:
             expected_logs = res.get('expected_logs')

--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -15,6 +15,8 @@ from flexer.utils import (
 import main
 import re
 
+skip_logs = False
+
 
 class BaseConnectorTest(unittest.TestCase):
     client = None
@@ -31,7 +33,8 @@ class BaseConnectorTest(unittest.TestCase):
         cls.account["credentials"] = (
             lookup_values(cls.account.get("credentials_keys"))
         )
-        cls.skip_logs = cls.account.get('skip_logs', False)
+        global skip_logs
+        skip_logs = cls.account.get('skip_logs', False)
         if "resources" in cls.account:
             cls.resource_data = cls.account.get("resources")
         else:
@@ -182,9 +185,8 @@ class BaseConnectorTest(unittest.TestCase):
 
     @unittest.skipIf(not hasattr(main, "get_logs"),
                      "get_logs not defined")
+    @unittest.skipIf(skip_logs,"skip logs flag raised")
     def test_get_logs(self):
-        if self.skip_logs:
-            return
         counter = 0
         for res in self.resource_data:
             expected_logs = res.get('expected_logs')


### PR DESCRIPTION
After trying to forcefully test logs on our current connector, we have come to realize that the nature of that test is extremely flaky and can even lead developers to modify their logic wrongly just to make them pass (example: do not set a resource id on azure logs connector).

Hence I'd like to add the ability to explicitly skip log testing by specifying:
```
skip_logs: true
```

on the config.yaml file.