### PR TITLE
Support account_id in single resource / per account schedule environment

### DIFF
--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -37,6 +37,7 @@ class BaseConnectorTest(unittest.TestCase):
         else:
             cls.resource_data = [
                 {
+                    "account_id": cls.account.get("account_id"),
                     "resource": cls.account.get("resource", {}),
                     "expected_metrics": cls.account.get("expected_metrics"),
                     "expected_logs": cls.account.get("expected_logs"),


### PR DESCRIPTION
We need to add the ability to set up the account id on a single resource environment to cope with the per account scheduling.

The format of the config.yaml when working on a connector that supports per-account scheduling would look something like this:

```yaml
name: provider
credentials_keys:
  - secret_access_key
  - access_key_id
account_id: some uui
resource:
  metadata:
    provider_specific:
      api_location: some location
  base:
    remote_id: some remote id
expected_metrics:
  - cpu-usage
expected_logs:
  - cpu-usage
expected_status:
  - 1
```

Let me know if what you think about this format or if we need to support multiple accounts.