### PR TITLE
Rename async variables to prevent invalid syntax in Python3

### DIFF
--- a/flexer/cli.py
+++ b/flexer/cli.py
@@ -404,7 +404,7 @@ def run(ctx, handler, event_source, event, config, secrets, pretty):
               help="The handler to execute inside the module")
 @click.argument('module_id')
 @pass_context
-def execute(ctx, module_id, handler, event, async, pretty):
+def execute(ctx, module_id, handler, event, is_async, pretty):
     """Run an nFlex module remotely.
 
     Call the CMP API to trigger a module execution remotely. EVENT must be a
@@ -418,7 +418,7 @@ def execute(ctx, module_id, handler, event, async, pretty):
         click.echo("warn: --pretty is deprecated", err=True)
 
     try:
-        result = ctx.nflex.execute(module_id, handler, async, event)
+        result = ctx.nflex.execute(module_id, handler, is_async, event)
     except requests.exceptions.RequestException as err:
         raise click.ClickException(
             "Failed to execute nFlex module: %s" % err

--- a/flexer/clients/nflex.py
+++ b/flexer/clients/nflex.py
@@ -21,9 +21,9 @@ class NflexClient(object):
     def get(self, module_id):
         return self._get('/modules/%s' % module_id).json()
 
-    def execute(self, module_id, handler, async, event):
+    def execute(self, module_id, handler, is_async, event):
         data = {
-            'async': async,
+            'async': is_async,
             'handler': "main.%s" % handler,
             'event': json.loads(event),
         }


### PR DESCRIPTION
Python3 introduced "async" keyword, which causes invalid syntax when doing flexer run.