### PR TITLE
Fixed issue with filter len for Python3

### DIFF
--- a/flexer/connector_tests/test_base.py
+++ b/flexer/connector_tests/test_base.py
@@ -93,7 +93,7 @@ class BaseConnectorTest(unittest.TestCase):
 
         expected_resources = self.account['expected_resources']
         for rtype in expected_resources:
-            count = len(filter(lambda r: r["type"] == rtype, resources))
+            count = len(list(filter(lambda r: r["type"] == rtype, resources)))
             self.assertGreater(count, 0,
                                'No resources of type "%s" found' % rtype)
 


### PR DESCRIPTION
Python3 returns an iterator that does not have the len method. By casting as a list this problem is fixed and it is possible to retrieve the len value even from Python3.