### PR TITLE
Send a useful User-Agent header from the CMP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v1.6.2](https://github.com/ntt-nflex/flexer/tree/v1.6.2) (Dec 04, 2018)
+[Full Changelog](https://github.com/ntt-nflex/flexer/compare/v1.6.1...v1.6.2)
+
+### Changes:
+- Send a useful User-Agent header from the CMP client [\#69](https://github.com/ntt-nflex/flexer/pull/69) ([@benpaxton-hf](https://github.com/benpaxton-hf))
+
 ## [v1.6.1](https://github.com/ntt-nflex/flexer/tree/v1.6.1) (Oct 29, 2018)
 [Full Changelog](https://github.com/ntt-nflex/flexer/compare/v1.6.0...v1.6.1)
 

--- a/flexer/__init__.py
+++ b/flexer/__init__.py
@@ -1,4 +1,4 @@
+__version__ = '1.6.1'
+
 from flexer.clients.cmp import CmpClient
 from flexer.clients.nflex import NflexClient
-
-__version__ = '1.6.1'

--- a/flexer/__init__.py
+++ b/flexer/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.6.1'
+__version__ = '1.6.2'
 
 from flexer.clients.cmp import CmpClient
 from flexer.clients.nflex import NflexClient

--- a/flexer/clients/cmp.py
+++ b/flexer/clients/cmp.py
@@ -1,17 +1,23 @@
 import requests
 import json
+from flexer.config import Config
 
 requests.packages.urllib3.disable_warnings()
 
 
 class CmpClient(object):
-    def __init__(self, url, auth=None, access_token=None, verify_ssl=None):
+    def __init__(self,
+                 url,
+                 auth=None,
+                 access_token=None,
+                 verify_ssl=None,
+                 user_agent=Config.USER_AGENT):
         self._session = requests.Session()
         self._url = url
         self._auth = auth
         self._access_token = access_token
         self._session.headers = {
-            'User-Agent': 'nflex-client',
+            'User-Agent': user_agent,
             'Content-Type': 'application/json',
         }
         self._session.verify = verify_ssl

--- a/flexer/config.py
+++ b/flexer/config.py
@@ -19,12 +19,18 @@ class Config(object):
     MODULE_ID = os.getenv('NFLEX_MODULE_ID')
     DB_KEY_PREFIX = '_nflexdb_'
 
-    USER_AGENT = "flexer/%s flexer_py%d%d/%s (module=%s)" % (
+    USER_AGENT = (
+        "flexer/%s "
+        "flexer_py%d%d/%s "
+        "(module=%s platform=%s region=%s)"
+    ) % (
         flexer.__version__,
         sys.version_info.major,
         sys.version_info.minor,
         FLEXER_VERSION or "unknown",
         MODULE_ID or "unknown",
+        CMP_PLATFORM or "unknown",
+        CMP_REGION or "unknown",
     )
 
 

--- a/flexer/config.py
+++ b/flexer/config.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import flexer
 
 CONFIG_FILE = os.path.expanduser('~/.flexer.yaml')
 DEFAULT_CMP_URL = 'https://sandbox.cmp.nflex.io/cmp/basic/api'
@@ -16,6 +18,14 @@ class Config(object):
     NFLEX_CODEDIR = os.getenv('NFLEX_CODEDIR', '/sandbox')
     MODULE_ID = os.getenv('NFLEX_MODULE_ID')
     DB_KEY_PREFIX = '_nflexdb_'
+
+    USER_AGENT = "flexer/%s flexer_py%d%d/%s (module=%s)" % (
+        flexer.__version__,
+        sys.version_info.major,
+        sys.version_info.minor,
+        FLEXER_VERSION or "unknown",
+        MODULE_ID or "unknown",
+    )
 
 
 class TestingConfig(Config):


### PR DESCRIPTION
Example header:
```
User-Agent: flexer/1.6.1 flexer_py27/dev (module=ae402290-23c5-4eb4-be1d-6810192e4c25)
```