### PR TITLE
Pin jsonschema to the last working version before the major version jump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 six
 click
 jinja2>=2.9.4
-jsonschema
+jsonschema==2.6.0
 requests
 pyyaml
 pymongo


### PR DESCRIPTION
Our python 3 flexer images are now failing to build due to requiring _jsonchema_ relying on _pkg_resources_. For now it's easier to pin _jsonchema_.

```
File "/libs/dist-packages/flexer/runner.py", line 11, in <module>
      from jsonschema import Draft4Validator
    File "/libs/dist-packages/jsonschema/__init__.py", line 32, in <module>
      from pkg_resources import get_distribution
  ImportError: No module named 'pkg_resources'
```