### PR TITLE
Use new PyYAML 5.1 loader method to remove warning

### DIFF
--- a/flexer/utils.py
+++ b/flexer/utils.py
@@ -43,7 +43,7 @@ def read_module(module):
 
 def read_yaml_file(file_name):
     with open(file_name) as f:
-        return yaml.load(f)
+        return yaml.full_load(f)
 
 
 def write_yaml_file(file_name, data):

--- a/flexer/utils.py
+++ b/flexer/utils.py
@@ -43,7 +43,7 @@ def read_module(module):
 
 def read_yaml_file(file_name):
     with open(file_name) as f:
-        return yaml.full_load(f)
+        return yaml.safe_load(f)
 
 
 def write_yaml_file(file_name, data):


### PR DESCRIPTION
Use yaml.full_load to remove the warning below everytime flexer was run

`../flexer/utils.py:46: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  return yaml.load(f)`