### PR TITLE
Add metric name pattern

### DIFF
--- a/flexer/validation/get_metrics.json
+++ b/flexer/validation/get_metrics.json
@@ -7,7 +7,8 @@
                 "type": "object",
                 "properties": {
                     "metric": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[-A-Za-z0-9:/_|\"\\' ]+$"
                     },
                     "original_metric": {
                         "type": "string"

--- a/flexer/validation/monitors.json
+++ b/flexer/validation/monitors.json
@@ -7,7 +7,8 @@
                 "type": "object",
                 "properties": {
                     "metric": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[-A-Za-z0-9:/_|\"\\' ]+$"
                     },
                     "value": {
                         "type": "number"


### PR DESCRIPTION
Currently you can only push metrics through the metrics API if the metric's name follows the pattern `^[-A-Za-z0-9:/_|"\' ]+$`.

For the sake of consistency, I believe we should do the same when pushing metrics to the system via monitors or metrics connectors.