### PR TITLE
Fix bug causing the message `execute() got an unexpected keyword argument 'async'`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v1.7.4](https://github.com/ntt-nflex/flexer/tree/v1.7.4) (July 30, 2020)
+
+[Full Changelog](https://github.com/ntt-nflex/flexer/compare/v1.7.3...v1.7.4)
+
+### Changes:
+
+- Fixed bug causing the message `execute() got an unexpected keyword argument 'async'`
+
 ## [v1.7.3](https://github.com/ntt-nflex/flexer/tree/v1.7.3) (Feb 14, 2020)
 
 [Full Changelog](https://github.com/ntt-nflex/flexer/compare/v1.7.2...v1.7.3)

--- a/flexer/cli.py
+++ b/flexer/cli.py
@@ -397,7 +397,7 @@ def run(ctx, handler, event_source, event, config, secrets, pretty):
 
 @cli.command()
 @click.option('--pretty', is_flag=True, help="DEPRECATED")
-@click.option('--async',
+@click.option('--async', 'is_async',
               default=False,
               is_flag=True,
               help="Whether to run the module asynchronously or not")


### PR DESCRIPTION
This was reported by @lcayolap. Unsure as to why it wasn't hit earlier.

Essentially, the `async` parameter was renamed to `is_async` without changing the corresponding `click` argument. According to [this](https://stackoverflow.com/a/42584302) StackOverflow answer this does not change the options available on the command line.

Please ensure you tag v1.7.4 as well as the previous tag, 1.7.3 (which is missing).