### PR TITLE
Add extra-headers field to .flexer.yaml to specify extra headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [v1.7.5](https://github.com/ntt-nflex/flexer/tree/v1.7.5) (June 10, 2021)
+
+[Full Changelog](https://github.com/ntt-nflex/flexer/compare/v1.7.4...v1.7.5)
+
+### Changes:
+
+- Add the property `extra-headers` in `.flexer.yaml` to specify additional headers.
+- Add `--extra-header` param to `flexer config add-region` to specify the above.
+
 ## [v1.7.4](https://github.com/ntt-nflex/flexer/tree/v1.7.4) (July 30, 2020)
 
 [Full Changelog](https://github.com/ntt-nflex/flexer/compare/v1.7.3...v1.7.4)

--- a/flexer/cli.py
+++ b/flexer/cli.py
@@ -101,6 +101,7 @@ def cli(ctx, auth):
 
     ctx.cmp = CmpClient(url=cfg['cmp_url'],
                         auth=(cfg['cmp_api_key'], cfg['cmp_api_secret']),
+                        extra_headers=cfg.get('extra_headers'),
                         verify_ssl=verify_ssl)
     ctx.nflex = NflexClient(ctx.cmp)
 
@@ -142,9 +143,15 @@ def config(ctx):
               metavar='NAME',
               required=True,
               help="The name of the region to add.")
-def add_region(name, url, key, secret):
+@click.option('--extra-header',
+              metavar='NAME VALUE',
+              nargs=2,
+              multiple=True,
+              help="Additional headers to include in the request. "
+              "(May be passed multiple times.)")
+def add_region(name, url, key, secret, extra_header):
     """Add a new region to the flexer config."""
-    flexer.commands.add_config_region(name, url, key, secret)
+    flexer.commands.add_config_region(name, url, key, secret, extra_header)
 
 
 @cli.command()

--- a/flexer/clients/cmp.py
+++ b/flexer/clients/cmp.py
@@ -9,6 +9,7 @@ class CmpClient(object):
     def __init__(self,
                  url,
                  auth=None,
+                 extra_headers=None,
                  access_token=None,
                  verify_ssl=None,
                  user_agent=Config.USER_AGENT):
@@ -16,10 +17,10 @@ class CmpClient(object):
         self._url = url
         self._auth = auth
         self._access_token = access_token
-        self._session.headers = {
+        self._session.headers = dict({
             'User-Agent': user_agent,
             'Content-Type': 'application/json',
-        }
+        }, **(extra_headers if extra_headers else {}))
         self._session.verify = verify_ssl
         if auth and len(auth) == 2 and auth[0] and auth[1]:
             self._session.auth = auth

--- a/flexer/commands.py
+++ b/flexer/commands.py
@@ -68,13 +68,18 @@ def config():
     return config
 
 
-def add_config_region(name, url, key, secret):
-    config = read_yaml_file(CONFIG_FILE)
-    config["regions"][str(name)] = {
+def add_config_region(name, url, key, secret, extra_headers):
+    new_region = {
         "cmp_url": str(url),
         "cmp_api_key": str(key),
         "cmp_api_secret": str(secret),
     }
+    if extra_headers:
+        new_region["extra_headers"] = \
+            {str(k): str(v) for k, v in extra_headers}
+
+    config = read_yaml_file(CONFIG_FILE)
+    config["regions"][str(name)] = new_region
     write_yaml_file(CONFIG_FILE, config)
     return config
 


### PR DESCRIPTION
This is useful for specifying e.g. `X-Cmp-Role`.

Also add the parameter `--extra-header NAME VALUE` to `flexer config add-region` to specify extra headers (may be passed multiple times).